### PR TITLE
Add WordPress home services site with scheduler and chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
-# RameezBusinessWebsite2025
-Rameez Business Website - Services
+# Rameez Business Website - Services
+
+This repository contains a basic WordPress setup for **R & J Brothers Services LLC**.
+
+## Features
+- Custom theme designed for home services (pressure washing, lawn care, painting, repairs, and more).
+- Service scheduling form storing requests in WordPress.
+- Simple chatbot integrating with the OpenAI API to answer common questions.
+- Docker setup for local development.
+
+## Getting Started
+1. Install [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/).
+2. Clone this repository and run:
+   ```bash
+   docker-compose up -d
+   ```
+3. Access WordPress at [http://localhost:8080](http://localhost:8080).
+4. Complete the WordPress installation wizard.
+5. Activate the **RJB Services** theme and the **RJB Scheduler** and **RJB Chatbot** plugins.
+6. Define an `OPENAI_API_KEY` constant in your `wp-config.php` to enable chatbot responses:
+   ```php
+   define('OPENAI_API_KEY', 'your_api_key_here');
+   ```
+
+## Notes
+- Appointments submitted via the scheduling form are stored as a custom post type `rjb_appointment`.
+- The chatbot uses the OpenAI Chat Completions API. Ensure you have an API key and sufficient quota.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+services:
+  db:
+    image: mysql:8.0
+    environment:
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+      MYSQL_ROOT_PASSWORD: wordpress
+    volumes:
+      - db_data:/var/lib/mysql
+    restart: always
+
+  wordpress:
+    image: wordpress:latest
+    depends_on:
+      - db
+    ports:
+      - "8080:80"
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_DB_NAME: wordpress
+    volumes:
+      - ./wp-content:/var/www/html/wp-content
+    restart: always
+
+volumes:
+  db_data:

--- a/wp-content/plugins/rjb-chatbot/css/chatbot.css
+++ b/wp-content/plugins/rjb-chatbot/css/chatbot.css
@@ -1,0 +1,35 @@
+#rjb-chatbot {
+  width: 300px;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+  font-family: Arial, sans-serif;
+}
+
+.rjb-chat-window {
+  display: flex;
+  flex-direction: column;
+  height: 400px;
+}
+
+.rjb-chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+.rjb-chat-messages p {
+  margin: 0.5rem 0;
+}
+
+.rjb-chat-messages p.user {
+  text-align: right;
+  color: #2563eb;
+}
+
+.rjb-chat-input {
+  border: none;
+  border-top: 1px solid #ccc;
+  padding: 0.5rem;
+}

--- a/wp-content/plugins/rjb-chatbot/js/chatbot.js
+++ b/wp-content/plugins/rjb-chatbot/js/chatbot.js
@@ -1,0 +1,52 @@
+(function(){
+  const container = document.getElementById('rjb-chatbot');
+  if(!container) return;
+
+  container.innerHTML = `
+    <div class="rjb-chat-window">
+      <div class="rjb-chat-messages"></div>
+      <input type="text" class="rjb-chat-input" placeholder="Ask a question..." />
+    </div>`;
+
+  const messagesEl = container.querySelector('.rjb-chat-messages');
+  const inputEl = container.querySelector('.rjb-chat-input');
+
+  async function sendMessage(message){
+    appendMessage('user', message);
+    inputEl.value='';
+
+    if(!rjbChatbot.apiKey){
+      appendMessage('bot', 'API key missing.');
+      return;
+    }
+
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' + rjbChatbot.apiKey
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [{role: 'system', content: 'You are a helpful assistant for R & J Brothers Services LLC.'},{role:'user', content: message}]
+      })
+    });
+    const data = await res.json();
+    const reply = data.choices && data.choices[0] ? data.choices[0].message.content : 'Sorry, an error occurred.';
+    appendMessage('bot', reply);
+  }
+
+  function appendMessage(sender, text){
+    const p=document.createElement('p');
+    p.className=sender;
+    p.textContent=text;
+    messagesEl.appendChild(p);
+    messagesEl.scrollTop=messagesEl.scrollHeight;
+  }
+
+  inputEl.addEventListener('keydown', function(e){
+    if(e.key==='Enter' && this.value.trim()){
+      sendMessage(this.value.trim());
+    }
+  });
+})();

--- a/wp-content/plugins/rjb-chatbot/rjb-chatbot.php
+++ b/wp-content/plugins/rjb-chatbot/rjb-chatbot.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Plugin Name: RJB Chatbot
+ * Description: Basic chatbot using OpenAI API for R & J Brothers Services FAQs.
+ * Version: 1.0
+ * Author: R & J Brothers Services LLC
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+function rjb_chatbot_enqueue() {
+    wp_enqueue_script( 'rjb-chatbot-js', plugin_dir_url( __FILE__ ) . 'js/chatbot.js', [], '1.0', true );
+    wp_enqueue_style( 'rjb-chatbot-css', plugin_dir_url( __FILE__ ) . 'css/chatbot.css', [], '1.0' );
+    wp_localize_script( 'rjb-chatbot-js', 'rjbChatbot', [
+        'apiKey' => defined('OPENAI_API_KEY') ? OPENAI_API_KEY : '',
+    ] );
+}
+add_action( 'wp_enqueue_scripts', 'rjb_chatbot_enqueue' );
+
+function rjb_chatbot_shortcode() {
+    return '<div id="rjb-chatbot"></div>';
+}
+add_shortcode( 'rjb_chatbot', 'rjb_chatbot_shortcode' );

--- a/wp-content/plugins/rjb-scheduler/rjb-scheduler.php
+++ b/wp-content/plugins/rjb-scheduler/rjb-scheduler.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Plugin Name: RJB Scheduler
+ * Description: Simple service scheduling form for R & J Brothers Services.
+ * Version: 1.0
+ * Author: R & J Brothers Services LLC
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+function rjb_register_appointment_cpt() {
+    $args = [
+        'public' => false,
+        'show_ui' => true,
+        'label' => 'Appointments',
+        'supports' => [ 'title', 'custom-fields' ],
+    ];
+    register_post_type( 'rjb_appointment', $args );
+}
+add_action( 'init', 'rjb_register_appointment_cpt' );
+
+function rjb_schedule_form_shortcode() {
+    if ( isset( $_POST['rjb_schedule_nonce'] ) && wp_verify_nonce( $_POST['rjb_schedule_nonce'], 'rjb_schedule' ) ) {
+        $name    = sanitize_text_field( $_POST['rjb_name'] );
+        $service = sanitize_text_field( $_POST['rjb_service'] );
+        $date    = sanitize_text_field( $_POST['rjb_date'] );
+
+        $post_id = wp_insert_post( [
+            'post_type'   => 'rjb_appointment',
+            'post_title'  => $name . ' - ' . $service,
+            'post_status' => 'publish',
+        ] );
+
+        if ( $post_id ) {
+            update_post_meta( $post_id, 'service', $service );
+            update_post_meta( $post_id, 'date', $date );
+            echo '<p>Thank you! We will contact you shortly to confirm your appointment.</p>';
+        }
+    }
+
+    ob_start();
+    ?>
+    <form method="post">
+      <?php wp_nonce_field( 'rjb_schedule', 'rjb_schedule_nonce' ); ?>
+      <p><label>Name<br><input type="text" name="rjb_name" required></label></p>
+      <p><label>Service<br><input type="text" name="rjb_service" required></label></p>
+      <p><label>Date<br><input type="date" name="rjb_date" required></label></p>
+      <p><button type="submit">Schedule</button></p>
+    </form>
+    <?php
+    return ob_get_clean();
+}
+add_shortcode( 'rjb_schedule_form', 'rjb_schedule_form_shortcode' );

--- a/wp-content/themes/rjb-services/footer.php
+++ b/wp-content/themes/rjb-services/footer.php
@@ -1,0 +1,6 @@
+<footer style="text-align:center;padding:1rem;background:#1f2937;color:#fff;">
+  &copy; <?php echo date('Y'); ?> R & J Brothers Services LLC
+</footer>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/wp-content/themes/rjb-services/front-page.php
+++ b/wp-content/themes/rjb-services/front-page.php
@@ -1,0 +1,32 @@
+<?php get_header(); ?>
+
+<div class="hero">
+  <h1>R & J Brothers Services LLC</h1>
+  <p>Your one-stop shop for home services.</p>
+</div>
+
+<section class="services">
+  <?php
+    $services = [
+      'Pressure Washing',
+      'Lawn Care',
+      'Painting',
+      'Home Repairs',
+      'Furniture Assembly'
+    ];
+    foreach ( $services as $service ) {
+      echo '<div class="service-card"><h3>' . esc_html( $service ) . '</h3></div>';
+    }
+  ?>
+</section>
+
+<section class="schedule-section">
+  <h2>Schedule a Service</h2>
+  <?php echo do_shortcode('[rjb_schedule_form]'); ?>
+</section>
+
+<div class="chatbot-section">
+  <?php echo do_shortcode('[rjb_chatbot]'); ?>
+</div>
+
+<?php get_footer(); ?>

--- a/wp-content/themes/rjb-services/functions.php
+++ b/wp-content/themes/rjb-services/functions.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * RJB Services Theme functions
+ */
+
+function rjb_services_setup() {
+    add_theme_support( 'title-tag' );
+    add_theme_support( 'post-thumbnails' );
+    register_nav_menus( [
+        'primary' => __( 'Primary Menu', 'rjb-services' ),
+    ] );
+}
+add_action( 'after_setup_theme', 'rjb_services_setup' );
+
+function rjb_services_scripts() {
+    wp_enqueue_style( 'rjb-services-style', get_stylesheet_uri(), [], '1.0' );
+}
+add_action( 'wp_enqueue_scripts', 'rjb_services_scripts' );

--- a/wp-content/themes/rjb-services/header.php
+++ b/wp-content/themes/rjb-services/header.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+<meta charset="<?php bloginfo( 'charset' ); ?>">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<header>
+  <h1><a href="<?php echo esc_url( home_url('/') ); ?>">R & J Brothers Services</a></h1>
+  <nav><?php wp_nav_menu( [ 'theme_location' => 'primary' ] ); ?></nav>
+</header>

--- a/wp-content/themes/rjb-services/style.css
+++ b/wp-content/themes/rjb-services/style.css
@@ -1,0 +1,73 @@
+/*
+Theme Name: RJB Services
+Theme URI: https://example.com/rjb-services
+Author: R & J Brothers Services LLC
+Description: Modern responsive theme tailored for home services businesses.
+Version: 1.0
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: rjb-services
+*/
+
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  line-height: 1.6;
+}
+
+header {
+  background: #1f2937;
+  color: #fff;
+  padding: 1rem;
+  text-align: center;
+}
+
+nav ul {
+  list-style: none;
+  display: flex;
+  justify-content: center;
+  padding: 0;
+  margin: 0;
+}
+
+nav li {
+  margin: 0 1rem;
+}
+
+nav a {
+  color: #fff;
+  text-decoration: none;
+}
+
+.hero {
+  background: url('../images/hero.jpg') center/cover no-repeat;
+  color: #fff;
+  padding: 5rem 1rem;
+  text-align: center;
+}
+
+.services {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+  padding: 2rem;
+}
+
+.service-card {
+  border: 1px solid #e5e5e5;
+  padding: 1rem;
+  border-radius: 4px;
+  background: #fff;
+}
+
+.schedule-section {
+  padding: 2rem;
+  background: #f9fafb;
+}
+
+.chatbot-section {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+}


### PR DESCRIPTION
## Summary
- create `RJB Services` WordPress theme with home page services grid and integration hooks
- add `RJB Scheduler` plugin for appointment requests via custom post type
- add `RJB Chatbot` plugin using OpenAI API
- provide Docker Compose for local WP setup and usage instructions

## Testing
- `php -l wp-content/themes/rjb-services/functions.php`
- `php -l wp-content/themes/rjb-services/front-page.php`
- `php -l wp-content/themes/rjb-services/header.php`
- `php -l wp-content/themes/rjb-services/footer.php`
- `php -l wp-content/plugins/rjb-scheduler/rjb-scheduler.php`
- `php -l wp-content/plugins/rjb-chatbot/rjb-chatbot.php`
- `node --check wp-content/plugins/rjb-chatbot/js/chatbot.js`


------
https://chatgpt.com/codex/tasks/task_e_68a3e8e778c883298204b83373c110e0