### PR TITLE
Add Render deployment configuration

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,34 @@
+services:
+  - type: web
+    name: wordpress
+    env: docker
+    image: wordpress:latest
+    plan: starter
+    port: 80
+    envVars:
+      - key: WORDPRESS_DB_HOST
+        fromDatabase:
+          name: wordpress-db
+          property: host
+      - key: WORDPRESS_DB_NAME
+        fromDatabase:
+          name: wordpress-db
+          property: database
+      - key: WORDPRESS_DB_USER
+        fromDatabase:
+          name: wordpress-db
+          property: user
+      - key: WORDPRESS_DB_PASSWORD
+        fromDatabase:
+          name: wordpress-db
+          property: password
+    disk:
+      name: wp-content
+      mountPath: /var/www/html/wp-content
+      sizeGB: 1
+
+databases:
+  - name: wordpress-db
+    plan: starter
+    databaseName: wordpress
+    user: wordpress


### PR DESCRIPTION
## Summary
- add `render.yaml` blueprint for deploying WordPress and MySQL on Render with persistent wp-content disk

## Testing
- `ruby -ryaml -e 'YAML.load_file("render.yaml"); puts "render.yaml valid"'`


------
https://chatgpt.com/codex/tasks/task_e_68a3f04cee7c8329ac3159dcbe5df8ae